### PR TITLE
Use default generate menu rather than a custom menu

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -49,9 +49,7 @@
     <!-- Add your actions here -->
     <group id="me.lotabout.codegenerator.action.CodeGeneratorMenu" class="me.lotabout.codegenerator.action.CodeGeneratorGroup" text="CodeGenerator"
            description="Code Generator" popup="true">
-      <add-to-group group-id="EditorPopupMenu2" anchor="after" relative-to-action="GenerateGroup"/>
-      <add-to-group group-id="ProjectViewPopupMenu" anchor="after" relative-to-action="ProjectViewPopupMenuRefactoringGroup"/>
-      <!--<add-to-group group-id="GenerateGroup" anchor="after" relative-to-action="JavaGenerateGroup2"/>-->
+      <add-to-group group-id="GenerateGroup" anchor="after" relative-to-action="JavaGenerateGroup2"/>
     </group>
   </actions>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -49,7 +49,8 @@
     <!-- Add your actions here -->
     <group id="me.lotabout.codegenerator.action.CodeGeneratorMenu" class="me.lotabout.codegenerator.action.CodeGeneratorGroup" text="CodeGenerator"
            description="Code Generator" popup="true">
-      <add-to-group group-id="GenerateGroup" anchor="after" relative-to-action="JavaGenerateGroup2"/>
+        <add-to-group group-id="ProjectViewPopupMenu" anchor="after" relative-to-action="ProjectViewPopupMenuRefactoringGroup"/>
+        <add-to-group group-id="GenerateGroup" anchor="after" relative-to-action="JavaGenerateGroup2"/>
     </group>
   </actions>
 


### PR DESCRIPTION
Fixes #4 

This adds is a sub-menu in `generate...` menu, and removes the previously existing menus. I personally would prefer to have the template actions directly in the menu, but I can see why someone would think that would be too cluttering. Also, that would, as far as I can tell, require adding the items to the menu programatically rather than in `plugin.xml`. Something along the lines of:

```java
@Override
public void initComponent() {
    ActionManager am = ActionManager.getInstance();
    DefaultActionGroup window = (DefaultActionGroup) am.getAction("JavaGenerateGroup2");

    am.addAnActionListener(new AnActionListener.Adapter() {
        private CodeGeneratorGroup group = new CodeGeneratorGroup();
        private AnAction[] actions;

        @Override
        public void beforeActionPerformed(AnAction action, DataContext dataContext, AnActionEvent event) {
            String id = am.getId(action);

            if (!id.equals("Generate")) {
                return;
            }

            actions = group.getChildren(event);

            for (AnAction anAction : actions) {
                window.add(anAction);
            }
        }

        @Override
        public void afterActionPerformed(AnAction action, DataContext dataContext, AnActionEvent event) {
            String id = am.getId(action);

            if (!id.equals("Generate")) {
                return;
            }

            for (AnAction anAction : actions) {
                window.remove(anAction);
            }     
        }
    });
}
```

What do you think?