### PR TITLE
Fix "Replace existing" policy when no existing member is found.

### DIFF
--- a/src/me/lotabout/codegenerator/worker/JavaBodyWorker.java
+++ b/src/me/lotabout/codegenerator/worker/JavaBodyWorker.java
@@ -76,7 +76,9 @@ public class JavaBodyWorker {
                 return;
             case REPLACE:
             case REPLACE_ALL:
-                membersToDelete.add(existingMember);
+                if (existingMember != null) {
+                    membersToDelete.add(existingMember);
+                }
                 break;
             }
             generationInfoList.add(new PsiGenerationInfo<>(member, false));


### PR DESCRIPTION
When the "replace existing" update policy is selected, the code generation fails if no existing members is found to overwrite. This change fixes this behaviour.